### PR TITLE
Revamp projects grid with link cards and summaries

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -1,92 +1,107 @@
 [
-    {
-        "id": 1,
-        "title": "Deposition Device",
-        "content": "<p>Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.</p>",
-        "imageUrl": "img/vup2-metal.jpg"
-    },
-    {
-        "id": 2,
-        "title": "Hydrogen Retention in Tore-Supra Tiles",
-        "content": "<p>We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns. It was found that most of hydrogen is retained in the deposited layers and top layers of the tile.<br> Moreover, hydrogen diffused deep inside the bulk of the graphite.</p>",
-        "imageUrl": "img/ToreSupra.png"
-    },
-    {
-        "id": 3,
-        "title": "Tungsten-Carbon Film Growth Model",
-        "content": "<p>Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma. The growth of the film was investigated at different stages. Scanning electron microscopy (SEM) to follow the development of surface morphology of the film. A growth model of two component film is proposed.</p>",
-        "imageUrl": "img/wcfilm.jpg"
-    },
-    {
-        "id": 4,
-        "title": "Oxygen Removal from Graphite Wall",
-        "content": "<p>We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.</p>",
-        "imageUrl": "img/CO2-m.png"
-    },
-    {
-        "id": 5,
-        "title": "Cell Adhesion Study",
-        "content": "<p>I developed a prototype device to investigate cell adhesion in a batch. To do so, we measured displacement of cells in the field of view and estimated the adhesion forces from the parameters of the actuater and measured dispacement. Cell identification is done automatically with the help of cellpose. Based on my prototype a US grant was won by my collaborators.</p>",
-        "imageUrl": "img/bioshake.png"
-    },
-    {
-        "id": 6,
-        "title": "Plasma Device Control Unit",
-        "content": "<p>An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI). The source code is availiable on <a href='https://github.com/queezz/ControlUnit'>GitHub</a></p>",
-        "imageUrl": "img/ControlUnit.png"
-    },
-    {
-        "id": 7,
-        "title": "X-ray Filter for Non-destructive Inspection",
-        "content": "<p>I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints. Significant improvement of the detection limit for defects was achived. This designed was patented, <a href='https://patents.google.com/patent/RU2530452C1/en?oq=RU2530452C1'>RU2530452C1</a>. </p>",
-        "imageUrl": "img/Xrayfilter.jpg"
-    },
-    {
-        "id": 8,
-        "title": "Permeation Experiments in QUEST",
-        "content": "<p>For several years I worked as a member of the QUEST tokamak team. I worked with membrane prboes to detect atomic and ionic hydrogen flux, coming to the walls of the device. Several iterations of the diagnostic were designed and adopted, and several papers regarding hydrogen recycling in QUEST were published.</p>",
-        "imageUrl": "img/kaainquest.jpg"
-    },
-    {
-        "id": 9,
-        "title": "Carbon impurity flow in LHD",
-        "content": "<p>I investigated carbon impurity flow in the perefiral plasma of Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>).</p>",
-        "imageUrl": "img/carbonflow.png"
-    },
-    {
-        "id": 10,
-        "title": "Boron powder plasma sputtering",
-        "content": "<p>I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.</p>",
-        "imageUrl": "img/boronpowder.jpg"
-    },
-    {
-        "id": 11,
-        "title": "Hydrogen Molecule Spectroscopy",
-        "content": "<p>We investigated population distribution of hydrogen molecules in Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>) perefiral plasma. The results show non-equilibrium distribution with two rotational temperatures.</p>",
-        "imageUrl": "img/fulcheralpha.png"
-    },
-    {
-        "id": 12,
-        "title": "Seawater Desalination Device",
-        "content": "<p>I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy. Plasma deposition was used to increase light absorptivity of the heat pipes to boil water.</p>",
-        "imageUrl": "img/CuFefilm.png"
-    },
-    {
-        "id": 13,
-        "title": "GUI for Echelle Spectrometer Image processing",
-        "content": "<p>The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra. The GUI is written in <a href='https://wiki.python.org/moin/PyQt'>pyqt</a> and relies on <a href='https://www.pyqtgraph.org/'>pyqtgrph</a> for fast plotting. See the project on <a href='https://github.com/queezz/echelle_spectra'>GitHub</a>.</p>",
-        "imageUrl": "img/echellegui.png"
-    },
-    {
-        "id": 14,
-        "title": "Oxygen Effect on Hydrogen Retention in Graphites",
-        "content": "<p>We've investigated how oxygen presence in hydrogen plasma affects retention in graphites. Turnes out, addition of a small concentration of oxygen leads to a tremendous increas in retention, even when ion irradiation energy is close to 0, or when irradiating graphites with only electrons.</p>",
-        "imageUrl": "img/D2O2-m.png"
-    },
-    {
-        "id": 15,
-        "title": "Fulcher-alpha Emission Analizer",
-        "content": "<p>This python project workes with molecular hydrogen Fulcher-alpha emission. It analized 1 and 2 temperature Boltzman distributino, and calculates rotational and vibrational temperatures of hydrogen molecules in the ground (X) and excieted (d) states. The code is avaliable on <a href='https://github.com/queezz/fulcheranalyzer'>GitHub</a>.</p>",
-        "imageUrl": "img/fulcheranalizer.png"
-    }
+  {
+    "id": 1,
+    "title": "Deposition Device",
+    "summary": "Device for simultaneous tungsten-carbon film deposition.",
+    "content": "<p>Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.</p>",
+    "imageUrl": "img/vup2-metal.jpg"
+  },
+  {
+    "id": 2,
+    "title": "Hydrogen Retention in Tore-Supra Tiles",
+    "summary": "Study of hydrogen retention in Tore-Supra tokamak tiles.",
+    "content": "<p>We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns. It was found that most of hydrogen is retained in the deposited layers and top layers of the tile.<br> Moreover, hydrogen diffused deep inside the bulk of the graphite.</p>",
+    "imageUrl": "img/ToreSupra.png"
+  },
+  {
+    "id": 3,
+    "title": "Tungsten-Carbon Film Growth Model",
+    "summary": "Modeling growth of W-C films during dual sputtering.",
+    "content": "<p>Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma. The growth of the film was investigated at different stages. Scanning electron microscopy (SEM) to follow the development of surface morphology of the film. A growth model of two component film is proposed.</p>",
+    "imageUrl": "img/wcfilm.jpg"
+  },
+  {
+    "id": 4,
+    "title": "Oxygen Removal from Graphite Wall",
+    "summary": "Glow discharge cleaning parameters for oxygen removal.",
+    "content": "<p>We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.</p>",
+    "imageUrl": "img/CO2-m.png"
+  },
+  {
+    "id": 5,
+    "title": "Cell Adhesion Study",
+    "summary": "Prototype to measure cell adhesion forces using automated tracking.",
+    "content": "<p>I developed a prototype device to investigate cell adhesion in a batch. To do so, we measured displacement of cells in the field of view and estimated the adhesion forces from the parameters of the actuater and measured dispacement. Cell identification is done automatically with the help of cellpose. Based on my prototype a US grant was won by my collaborators.</p>",
+    "imageUrl": "img/bioshake.png"
+  },
+  {
+    "id": 6,
+    "title": "Plasma Device Control Unit",
+    "summary": "Open-source control and acquisition unit for plasma experiments.",
+    "content": "<p>An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI). The source code is availiable on <a href='https://github.com/queezz/ControlUnit'>GitHub</a></p>",
+    "imageUrl": "img/ControlUnit.png"
+  },
+  {
+    "id": 7,
+    "title": "X-ray Filter for Non-destructive Inspection",
+    "summary": "Improved X-ray filter design for weld inspection.",
+    "content": "<p>I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints. Significant improvement of the detection limit for defects was achived. This designed was patented, <a href='https://patents.google.com/patent/RU2530452C1/en?oq=RU2530452C1'>RU2530452C1</a>. </p>",
+    "imageUrl": "img/Xrayfilter.jpg"
+  },
+  {
+    "id": 8,
+    "title": "Permeation Experiments in QUEST",
+    "summary": "Hydrogen flux measurements with membrane probes in QUEST tokamak.",
+    "content": "<p>For several years I worked as a member of the QUEST tokamak team. I worked with membrane prboes to detect atomic and ionic hydrogen flux, coming to the walls of the device. Several iterations of the diagnostic were designed and adopted, and several papers regarding hydrogen recycling in QUEST were published.</p>",
+    "imageUrl": "img/kaainquest.jpg"
+  },
+  {
+    "id": 9,
+    "title": "Carbon impurity flow in LHD",
+    "summary": "Analysis of carbon impurity transport in LHD peripheral plasma.",
+    "content": "<p>I investigated carbon impurity flow in the perefiral plasma of Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>).</p>",
+    "imageUrl": "img/carbonflow.png"
+  },
+  {
+    "id": 10,
+    "title": "Boron powder plasma sputtering",
+    "summary": "Prototype sputtering device for boron powder deposition.",
+    "content": "<p>I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.</p>",
+    "imageUrl": "img/boronpowder.jpg"
+  },
+  {
+    "id": 11,
+    "title": "Hydrogen Molecule Spectroscopy",
+    "summary": "Spectroscopy of hydrogen molecule populations in LHD plasma.",
+    "content": "<p>We investigated population distribution of hydrogen molecules in Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>) perefiral plasma. The results show non-equilibrium distribution with two rotational temperatures.</p>",
+    "imageUrl": "img/fulcheralpha.png"
+  },
+  {
+    "id": 12,
+    "title": "Seawater Desalination Device",
+    "summary": "Renewable-powered multi-effect evaporation desalination system.",
+    "content": "<p>I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy. Plasma deposition was used to increase light absorptivity of the heat pipes to boil water.</p>",
+    "imageUrl": "img/CuFefilm.png"
+  },
+  {
+    "id": 13,
+    "title": "GUI for Echelle Spectrometer Image processing",
+    "summary": "PyQt GUI converts 2D echelle images to calibrated spectra.",
+    "content": "<p>The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra. The GUI is written in <a href='https://wiki.python.org/moin/PyQt'>pyqt</a> and relies on <a href='https://www.pyqtgraph.org/'>pyqtgrph</a> for fast plotting. See the project on <a href='https://github.com/queezz/echelle_spectra'>GitHub</a>.</p>",
+    "imageUrl": "img/echellegui.png"
+  },
+  {
+    "id": 14,
+    "title": "Oxygen Effect on Hydrogen Retention in Graphites",
+    "summary": "Oxygen addition drastically increases hydrogen retention in graphites.",
+    "content": "<p>We've investigated how oxygen presence in hydrogen plasma affects retention in graphites. Turnes out, addition of a small concentration of oxygen leads to a tremendous increas in retention, even when ion irradiation energy is close to 0, or when irradiating graphites with only electrons.</p>",
+    "imageUrl": "img/D2O2-m.png"
+  },
+  {
+    "id": 15,
+    "title": "Fulcher-alpha Emission Analizer",
+    "summary": "Python tool for analyzing molecular hydrogen Fulcher-alpha emission.",
+    "content": "<p>This python project workes with molecular hydrogen Fulcher-alpha emission. It analized 1 and 2 temperature Boltzman distributino, and calculates rotational and vibrational temperatures of hydrogen molecules in the ground (X) and excited (d) states. The code is avaliable on <a href='https://github.com/queezz/fulcheranalyzer'>GitHub</a>.</p>",
+    "imageUrl": "img/fulcheranalizer.png"
+  }
 ]

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -6,59 +6,22 @@ async function fetchData() {
 
         const gridContainer = document.getElementById('gridContainer');
 
-        // Create grid items and popups based on the data
+        // Create link cards based on the data
         data.forEach(item => {
-            // Create grid item
-            const gridItem = document.createElement('div');
-            gridItem.className = 'grid-item';
-            gridItem.style.backgroundImage = `url(${item.imageUrl})`;
-            gridItem.innerHTML = `<h2>${item.title}</h2>`;
-            gridItem.onclick = () => openPopup(item.id);
-            gridContainer.appendChild(gridItem);
-
-            // Create popup container
-            const popupContainer = document.createElement('div');
-            popupContainer.className = 'popup-container';
-            popupContainer.id = `popup${item.id}`;
-            popupContainer.style.display = 'none';
-
-            // Create popup content
-            const popupContent = document.createElement('div');
-            popupContent.className = 'popup-content';
-            popupContent.innerHTML = `
-    <span class="close-button" onclick="closePopup(${item.id})">X</span>
-    <h2>${item.title}</h2>
-    <img src="${item.imageUrl}" alt="${item.title}">
-    ${item.content}
-        `;
-            popupContainer.appendChild(popupContent);
-
-            // Add popup container to the body
-            document.body.appendChild(popupContainer);
+            const card = document.createElement('a');
+            card.className = 'grid-item';
+            card.href = `project.html?id=${item.id}`;
+            card.innerHTML = `
+                <img src="${item.imageUrl}" alt="${item.title}">
+                <h2>${item.title}</h2>
+                <p>${item.summary}</p>
+            `;
+            gridContainer.appendChild(card);
         });
     } catch (error) {
         console.error('Error fetching data:', error);
     }
 }
 
-// Function to open a popup
-function openPopup(popupId) {
-    const popup = document.getElementById(`popup${popupId}`);
-    popup.style.display = 'flex';
-
-    // Add an event listener to close the popup when clicking on the background
-    popup.addEventListener('click', function (event) {
-        if (event.target === popup) {
-            closePopup(popupId);
-        }
-    });
-}
-
-// Function to close a popup
-function closePopup(popupId) {
-    const popup = document.getElementById(`popup${popupId}`);
-    popup.style.display = 'none';
-}
-
-// Call the fetchData function to populate the grid and popups
+// Call the fetchData function to populate the grid
 fetchData();

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -1,101 +1,45 @@
 /* Grid container */
 .grid-container {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
-    max-width: 800px;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    max-width: 1000px;
     margin: 0 auto;
 }
-
 
 body {
     padding-left: 2px;
 }
 
-/* Grid items (square) */
-
+/* Card items */
 .grid-item {
-    width: 190px;
-    /* Set the width of each grid item */
-    height: 190px;
-    /* Set the height of each grid item to make them square */
-    background-size: cover;
-    background-position: center;
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    color: inherit;
     border: 2px solid rgba(255, 4, 4, 0.2);
-    /* Transparent border around each grid item */
     border-radius: 5px;
-    cursor: pointer;
-    position: relative;
-    /* Relative positioning for the overlay content */
+    overflow: hidden;
+}
+
+.grid-item img {
+    width: 100%;
+    height: auto;
+    display: block;
 }
 
 .grid-item h2 {
-    position: absolute;
     font-size: larger;
-    top: 40%;
-    /* Vertically center the header */
-    left: 50%;
-    /* Horizontally center the header */
-    transform: translate(-50%, -50%);
-    /* Center it perfectly */
-    background-color: rgba(214, 143, 143, 0.774);
-    /* Semi-transparent white background */
-    padding: 5px 10px;
-    /* Adjust padding as needed */
-    border-radius: 5px;
-    width: 100%;
+    margin: 10px;
+}
+
+.grid-item p {
+    margin: 0 10px 10px;
 }
 
 @media (max-width: 800px) {
-    .grid-item {
-        width: 170px;
-        height: 170px;
-    }
-
-    .grid-item h2 {
-        width: 90%;
+    .grid-container {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     }
 }
 
-
-/* Popup container */
-.popup-container {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(199, 135, 135, 0.9);
-    /* Lighter background */
-    justify-content: center;
-    align-items: center;
-}
-
-/* Popup content */
-.popup-content {
-    background-color: white;
-    max-width: 400px;
-    padding: 20px;
-    border-radius: 8px;
-    text-align: center;
-    position: relative;
-}
-
-.popup-content p {
-    text-align: left;
-}
-
-/* Close button */
-.close-button {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    cursor: pointer;
-}
-
-/* Make images within popups responsive */
-.popup-content img {
-    max-width: 100%;
-    height: auto;
-}


### PR DESCRIPTION
## Summary
- Convert project popup system into grid of anchor cards linking to dedicated project pages
- Introduce summary snippets for each project and display them alongside images and titles
- Simplify CSS to style responsive card grid for desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx playwright@latest install chromium` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68982bba95c0832aa8db10293caee1cc