### PR TITLE
Refactor project data to use markdown summaries

### DIFF
--- a/data/project/1.md
+++ b/data/project/1.md
@@ -1,0 +1,1 @@
+Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.

--- a/data/project/10.md
+++ b/data/project/10.md
@@ -1,0 +1,1 @@
+I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.

--- a/data/project/11.md
+++ b/data/project/11.md
@@ -1,0 +1,1 @@
+We investigated population distribution of hydrogen molecules in Large Helical Device ([LHD](https://en.wikipedia.org/wiki/Large_Helical_Device)) perefiral plasma. The results show non-equilibrium distribution with two rotational temperatures.

--- a/data/project/12.md
+++ b/data/project/12.md
@@ -1,0 +1,1 @@
+I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy. Plasma deposition was used to increase light absorptivity of the heat pipes to boil water.

--- a/data/project/13.md
+++ b/data/project/13.md
@@ -1,0 +1,1 @@
+The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra. The GUI is written in [pyqt](https://wiki.python.org/moin/PyQt) and relies on [pyqtgrph](https://www.pyqtgraph.org/) for fast plotting. See the project on [GitHub](https://github.com/queezz/echelle_spectra).

--- a/data/project/14.md
+++ b/data/project/14.md
@@ -1,0 +1,1 @@
+We've investigated how oxygen presence in hydrogen plasma affects retention in graphites. Turnes out, addition of a small concentration of oxygen leads to a tremendous increas in retention, even when ion irradiation energy is close to 0, or when irradiating graphites with only electrons.

--- a/data/project/15.md
+++ b/data/project/15.md
@@ -1,0 +1,1 @@
+This python project workes with molecular hydrogen Fulcher-alpha emission. It analized 1 and 2 temperature Boltzman distributino, and calculates rotational and vibrational temperatures of hydrogen molecules in the ground (X) and excieted (d) states. The code is avaliable on [GitHub](https://github.com/queezz/fulcheranalyzer).

--- a/data/project/2.md
+++ b/data/project/2.md
@@ -1,0 +1,2 @@
+We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns. It was found that most of hydrogen is retained in the deposited layers and top layers of the tile.
+ Moreover, hydrogen diffused deep inside the bulk of the graphite.

--- a/data/project/3.md
+++ b/data/project/3.md
@@ -1,0 +1,1 @@
+Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma. The growth of the film was investigated at different stages. Scanning electron microscopy (SEM) to follow the development of surface morphology of the film. A growth model of two component film is proposed.

--- a/data/project/4.md
+++ b/data/project/4.md
@@ -1,0 +1,1 @@
+We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.

--- a/data/project/5.md
+++ b/data/project/5.md
@@ -1,0 +1,1 @@
+I developed a prototype device to investigate cell adhesion in a batch. To do so, we measured displacement of cells in the field of view and estimated the adhesion forces from the parameters of the actuater and measured dispacement. Cell identification is done automatically with the help of cellpose. Based on my prototype a US grant was won by my collaborators.

--- a/data/project/6.md
+++ b/data/project/6.md
@@ -1,0 +1,1 @@
+An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI). The source code is availiable on [GitHub](https://github.com/queezz/ControlUnit)

--- a/data/project/7.md
+++ b/data/project/7.md
@@ -1,0 +1,1 @@
+I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints. Significant improvement of the detection limit for defects was achived. This designed was patented, [RU2530452C1](https://patents.google.com/patent/RU2530452C1/en?oq=RU2530452C1).

--- a/data/project/8.md
+++ b/data/project/8.md
@@ -1,0 +1,1 @@
+For several years I worked as a member of the QUEST tokamak team. I worked with membrane prboes to detect atomic and ionic hydrogen flux, coming to the walls of the device. Several iterations of the diagnostic were designed and adopted, and several papers regarding hydrogen recycling in QUEST were published.

--- a/data/project/9.md
+++ b/data/project/9.md
@@ -1,0 +1,1 @@
+I investigated carbon impurity flow in the perefiral plasma of Large Helical Device ([LHD](https://en.wikipedia.org/wiki/Large_Helical_Device)).

--- a/data/projects.json
+++ b/data/projects.json
@@ -2,91 +2,106 @@
     {
         "id": 1,
         "title": "Deposition Device",
-        "content": "<p>Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.</p>",
+        "summary": "Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.",
+        "markdown": "data/project/1.md",
         "imageUrl": "img/vup2-metal.jpg"
     },
     {
         "id": 2,
         "title": "Hydrogen Retention in Tore-Supra Tiles",
-        "content": "<p>We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns. It was found that most of hydrogen is retained in the deposited layers and top layers of the tile.<br> Moreover, hydrogen diffused deep inside the bulk of the graphite.</p>",
+        "summary": "We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns.",
+        "markdown": "data/project/2.md",
         "imageUrl": "img/ToreSupra.png"
     },
     {
         "id": 3,
         "title": "Tungsten-Carbon Film Growth Model",
-        "content": "<p>Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma. The growth of the film was investigated at different stages. Scanning electron microscopy (SEM) to follow the development of surface morphology of the film. A growth model of two component film is proposed.</p>",
+        "summary": "Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma.",
+        "markdown": "data/project/3.md",
         "imageUrl": "img/wcfilm.jpg"
     },
     {
         "id": 4,
         "title": "Oxygen Removal from Graphite Wall",
-        "content": "<p>We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.</p>",
+        "summary": "We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.",
+        "markdown": "data/project/4.md",
         "imageUrl": "img/CO2-m.png"
     },
     {
         "id": 5,
         "title": "Cell Adhesion Study",
-        "content": "<p>I developed a prototype device to investigate cell adhesion in a batch. To do so, we measured displacement of cells in the field of view and estimated the adhesion forces from the parameters of the actuater and measured dispacement. Cell identification is done automatically with the help of cellpose. Based on my prototype a US grant was won by my collaborators.</p>",
+        "summary": "I developed a prototype device to investigate cell adhesion in a batch.",
+        "markdown": "data/project/5.md",
         "imageUrl": "img/bioshake.png"
     },
     {
         "id": 6,
         "title": "Plasma Device Control Unit",
-        "content": "<p>An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI). The source code is availiable on <a href='https://github.com/queezz/ControlUnit'>GitHub</a></p>",
+        "summary": "An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI).",
+        "markdown": "data/project/6.md",
         "imageUrl": "img/ControlUnit.png"
     },
     {
         "id": 7,
         "title": "X-ray Filter for Non-destructive Inspection",
-        "content": "<p>I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints. Significant improvement of the detection limit for defects was achived. This designed was patented, <a href='https://patents.google.com/patent/RU2530452C1/en?oq=RU2530452C1'>RU2530452C1</a>. </p>",
+        "summary": "I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints.",
+        "markdown": "data/project/7.md",
         "imageUrl": "img/Xrayfilter.jpg"
     },
     {
         "id": 8,
         "title": "Permeation Experiments in QUEST",
-        "content": "<p>For several years I worked as a member of the QUEST tokamak team. I worked with membrane prboes to detect atomic and ionic hydrogen flux, coming to the walls of the device. Several iterations of the diagnostic were designed and adopted, and several papers regarding hydrogen recycling in QUEST were published.</p>",
+        "summary": "For several years I worked as a member of the QUEST tokamak team.",
+        "markdown": "data/project/8.md",
         "imageUrl": "img/kaainquest.jpg"
     },
     {
         "id": 9,
         "title": "Carbon impurity flow in LHD",
-        "content": "<p>I investigated carbon impurity flow in the perefiral plasma of Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>).</p>",
+        "summary": "I investigated carbon impurity flow in the perefiral plasma of Large Helical Device ([LHD](https://en.wikipedia.org/wiki/Large_Helical_Device)).",
+        "markdown": "data/project/9.md",
         "imageUrl": "img/carbonflow.png"
     },
     {
         "id": 10,
         "title": "Boron powder plasma sputtering",
-        "content": "<p>I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.</p>",
+        "summary": "I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.",
+        "markdown": "data/project/10.md",
         "imageUrl": "img/boronpowder.jpg"
     },
     {
         "id": 11,
         "title": "Hydrogen Molecule Spectroscopy",
-        "content": "<p>We investigated population distribution of hydrogen molecules in Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>) perefiral plasma. The results show non-equilibrium distribution with two rotational temperatures.</p>",
+        "summary": "We investigated population distribution of hydrogen molecules in Large Helical Device ([LHD](https://en.wikipedia.org/wiki/Large_Helical_Device)) perefiral plasma.",
+        "markdown": "data/project/11.md",
         "imageUrl": "img/fulcheralpha.png"
     },
     {
         "id": 12,
         "title": "Seawater Desalination Device",
-        "content": "<p>I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy. Plasma deposition was used to increase light absorptivity of the heat pipes to boil water.</p>",
+        "summary": "I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy.",
+        "markdown": "data/project/12.md",
         "imageUrl": "img/CuFefilm.png"
     },
     {
         "id": 13,
         "title": "GUI for Echelle Spectrometer Image processing",
-        "content": "<p>The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra. The GUI is written in <a href='https://wiki.python.org/moin/PyQt'>pyqt</a> and relies on <a href='https://www.pyqtgraph.org/'>pyqtgrph</a> for fast plotting. See the project on <a href='https://github.com/queezz/echelle_spectra'>GitHub</a>.</p>",
+        "summary": "The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra.",
+        "markdown": "data/project/13.md",
         "imageUrl": "img/echellegui.png"
     },
     {
         "id": 14,
         "title": "Oxygen Effect on Hydrogen Retention in Graphites",
-        "content": "<p>We've investigated how oxygen presence in hydrogen plasma affects retention in graphites. Turnes out, addition of a small concentration of oxygen leads to a tremendous increas in retention, even when ion irradiation energy is close to 0, or when irradiating graphites with only electrons.</p>",
+        "summary": "We've investigated how oxygen presence in hydrogen plasma affects retention in graphites.",
+        "markdown": "data/project/14.md",
         "imageUrl": "img/D2O2-m.png"
     },
     {
         "id": 15,
         "title": "Fulcher-alpha Emission Analizer",
-        "content": "<p>This python project workes with molecular hydrogen Fulcher-alpha emission. It analized 1 and 2 temperature Boltzman distributino, and calculates rotational and vibrational temperatures of hydrogen molecules in the ground (X) and excieted (d) states. The code is avaliable on <a href='https://github.com/queezz/fulcheranalyzer'>GitHub</a>.</p>",
+        "summary": "This python project workes with molecular hydrogen Fulcher-alpha emission.",
+        "markdown": "data/project/15.md",
         "imageUrl": "img/fulcheranalizer.png"
     }
 ]

--- a/project.html
+++ b/project.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        if (localStorage.getItem('darkMode') === '1') {
+            document.documentElement.classList.add('dark-mode');
+        }
+    </script>
+    <meta charset="UTF-8">
+    <title>Project Detail</title>
+    <link rel="stylesheet" href="styles/styles.css">
+</head>
+<body>
+    <script src="scripts/navbar.js"></script>
+    <script src="scripts/scroltotop.js"></script>
+    <div class="scroll-to-top-button" id="scrollToTopButton"><span class="scroll-to-top-arrow"></span></div>
+    <div class="main-content">
+        <nav id="navbar"></nav>
+        <h1 id="projectTitle"></h1>
+        <div id="projectContent"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="scripts/project.js"></script>
+</body>
+</html>

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -1,0 +1,22 @@
+async function loadProject() {
+    const params = new URLSearchParams(window.location.search);
+    const markdownPath = params.get('markdown');
+    const title = params.get('title') || 'Project';
+    const titleElement = document.getElementById('projectTitle');
+    const contentElement = document.getElementById('projectContent');
+    titleElement.textContent = title;
+    document.title = `Project: ${title}`;
+    if (markdownPath) {
+        try {
+            const response = await fetch(markdownPath);
+            const text = await response.text();
+            contentElement.innerHTML = marked.parse(text);
+        } catch (error) {
+            console.error('Error loading markdown:', error);
+            contentElement.textContent = 'Unable to load project details.';
+        }
+    } else {
+        contentElement.textContent = 'Project not specified.';
+    }
+}
+loadProject();

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -1,64 +1,25 @@
 // Function to fetch and populate data
 async function fetchData() {
     try {
-        const response = await fetch('data/projects.json'); // Replace with the path to your JSON file
+        const response = await fetch('data/projects.json');
         const data = await response.json();
 
         const gridContainer = document.getElementById('gridContainer');
 
-        // Create grid items and popups based on the data
         data.forEach(item => {
-            // Create grid item
             const gridItem = document.createElement('div');
             gridItem.className = 'grid-item';
             gridItem.style.backgroundImage = `url(${item.imageUrl})`;
-            gridItem.innerHTML = `<h2>${item.title}</h2>`;
-            gridItem.onclick = () => openPopup(item.id);
+            gridItem.innerHTML = `<h2>${item.summary}</h2>`;
+            gridItem.onclick = () => {
+                const url = `project.html?title=${encodeURIComponent(item.title)}&markdown=${encodeURIComponent(item.markdown)}`;
+                window.location.href = url;
+            };
             gridContainer.appendChild(gridItem);
-
-            // Create popup container
-            const popupContainer = document.createElement('div');
-            popupContainer.className = 'popup-container';
-            popupContainer.id = `popup${item.id}`;
-            popupContainer.style.display = 'none';
-
-            // Create popup content
-            const popupContent = document.createElement('div');
-            popupContent.className = 'popup-content';
-            popupContent.innerHTML = `
-    <span class="close-button" onclick="closePopup(${item.id})">X</span>
-    <h2>${item.title}</h2>
-    <img src="${item.imageUrl}" alt="${item.title}">
-    ${item.content}
-        `;
-            popupContainer.appendChild(popupContent);
-
-            // Add popup container to the body
-            document.body.appendChild(popupContainer);
         });
     } catch (error) {
         console.error('Error fetching data:', error);
     }
 }
 
-// Function to open a popup
-function openPopup(popupId) {
-    const popup = document.getElementById(`popup${popupId}`);
-    popup.style.display = 'flex';
-
-    // Add an event listener to close the popup when clicking on the background
-    popup.addEventListener('click', function (event) {
-        if (event.target === popup) {
-            closePopup(popupId);
-        }
-    });
-}
-
-// Function to close a popup
-function closePopup(popupId) {
-    const popup = document.getElementById(`popup${popupId}`);
-    popup.style.display = 'none';
-}
-
-// Call the fetchData function to populate the grid and popups
 fetchData();


### PR DESCRIPTION
## Summary
- replace `content` with `summary` and `markdown` in project data
- add per-project markdown descriptions and new detail page
- update project scripts to use summaries and load markdown details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982b6fd838832aacd279d395f30b6d