### PR TITLE
Switch project details to markdown and add detail pages

### DIFF
--- a/data/project_details/1.md
+++ b/data/project_details/1.md
@@ -1,0 +1,1 @@
+Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.

--- a/data/project_details/10.md
+++ b/data/project_details/10.md
@@ -1,0 +1,1 @@
+I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.

--- a/data/project_details/11.md
+++ b/data/project_details/11.md
@@ -1,0 +1,1 @@
+We investigated population distribution of hydrogen molecules in Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>) perefiral plasma. The results show non-equilibrium distribution with two rotational temperatures.

--- a/data/project_details/12.md
+++ b/data/project_details/12.md
@@ -1,0 +1,1 @@
+I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy. Plasma deposition was used to increase light absorptivity of the heat pipes to boil water.

--- a/data/project_details/13.md
+++ b/data/project_details/13.md
@@ -1,0 +1,1 @@
+The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra. The GUI is written in <a href='https://wiki.python.org/moin/PyQt'>pyqt</a> and relies on <a href='https://www.pyqtgraph.org/'>pyqtgrph</a> for fast plotting. See the project on <a href='https://github.com/queezz/echelle_spectra'>GitHub</a>.

--- a/data/project_details/14.md
+++ b/data/project_details/14.md
@@ -1,0 +1,1 @@
+We've investigated how oxygen presence in hydrogen plasma affects retention in graphites. Turnes out, addition of a small concentration of oxygen leads to a tremendous increas in retention, even when ion irradiation energy is close to 0, or when irradiating graphites with only electrons.

--- a/data/project_details/15.md
+++ b/data/project_details/15.md
@@ -1,0 +1,1 @@
+This python project workes with molecular hydrogen Fulcher-alpha emission. It analized 1 and 2 temperature Boltzman distributino, and calculates rotational and vibrational temperatures of hydrogen molecules in the ground (X) and excited (d) states. The code is avaliable on <a href='https://github.com/queezz/fulcheranalyzer'>GitHub</a>.

--- a/data/project_details/2.md
+++ b/data/project_details/2.md
@@ -1,0 +1,2 @@
+We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns. It was found that most of hydrogen is retained in the deposited layers and top layers of the tile.
+ Moreover, hydrogen diffused deep inside the bulk of the graphite.

--- a/data/project_details/3.md
+++ b/data/project_details/3.md
@@ -1,0 +1,1 @@
+Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma. The growth of the film was investigated at different stages. Scanning electron microscopy (SEM) to follow the development of surface morphology of the film. A growth model of two component film is proposed.

--- a/data/project_details/4.md
+++ b/data/project_details/4.md
@@ -1,0 +1,1 @@
+We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.

--- a/data/project_details/5.md
+++ b/data/project_details/5.md
@@ -1,0 +1,1 @@
+I developed a prototype device to investigate cell adhesion in a batch. To do so, we measured displacement of cells in the field of view and estimated the adhesion forces from the parameters of the actuater and measured dispacement. Cell identification is done automatically with the help of cellpose. Based on my prototype a US grant was won by my collaborators.

--- a/data/project_details/6.md
+++ b/data/project_details/6.md
@@ -1,0 +1,1 @@
+An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI). The source code is availiable on <a href='https://github.com/queezz/ControlUnit'>GitHub</a>

--- a/data/project_details/7.md
+++ b/data/project_details/7.md
@@ -1,0 +1,1 @@
+I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints. Significant improvement of the detection limit for defects was achived. This designed was patented, <a href='https://patents.google.com/patent/RU2530452C1/en?oq=RU2530452C1'>RU2530452C1</a>.

--- a/data/project_details/8.md
+++ b/data/project_details/8.md
@@ -1,0 +1,1 @@
+For several years I worked as a member of the QUEST tokamak team. I worked with membrane prboes to detect atomic and ionic hydrogen flux, coming to the walls of the device. Several iterations of the diagnostic were designed and adopted, and several papers regarding hydrogen recycling in QUEST were published.

--- a/data/project_details/9.md
+++ b/data/project_details/9.md
@@ -1,0 +1,1 @@
+I investigated carbon impurity flow in the perefiral plasma of Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>).

--- a/data/projects.json
+++ b/data/projects.json
@@ -3,105 +3,105 @@
     "id": 1,
     "title": "Deposition Device",
     "summary": "Device for simultaneous tungsten-carbon film deposition.",
-    "content": "<p>Multi material deposition device was developed to investigate the growth tungsten-carbon films during simultaneous deposition.</p>",
-    "imageUrl": "img/vup2-metal.jpg"
+    "imageUrl": "img/vup2-metal.jpg",
+    "markdownUrl": "data/project_details/1.md"
   },
   {
     "id": 2,
     "title": "Hydrogen Retention in Tore-Supra Tiles",
     "summary": "Study of hydrogen retention in Tore-Supra tokamak tiles.",
-    "content": "<p>We investigated hydrogen retention in Tore-Supra tokamak tiles after they were exposed to the plasma for several campaigns. It was found that most of hydrogen is retained in the deposited layers and top layers of the tile.<br> Moreover, hydrogen diffused deep inside the bulk of the graphite.</p>",
-    "imageUrl": "img/ToreSupra.png"
+    "imageUrl": "img/ToreSupra.png",
+    "markdownUrl": "data/project_details/2.md"
   },
   {
     "id": 3,
     "title": "Tungsten-Carbon Film Growth Model",
     "summary": "Modeling growth of W-C films during dual sputtering.",
-    "content": "<p>Tungsten-Carbon film is deposited by simultaneous spattering of W and C targets by ions from Ar+H plasma. The growth of the film was investigated at different stages. Scanning electron microscopy (SEM) to follow the development of surface morphology of the film. A growth model of two component film is proposed.</p>",
-    "imageUrl": "img/wcfilm.jpg"
+    "imageUrl": "img/wcfilm.jpg",
+    "markdownUrl": "data/project_details/3.md"
   },
   {
     "id": 4,
     "title": "Oxygen Removal from Graphite Wall",
     "summary": "Glow discharge cleaning parameters for oxygen removal.",
-    "content": "<p>We searched for optimal parameters for glow discharge cleaning to remove oxygen from graphite tiles in Tore-Supra tokamak.</p>",
-    "imageUrl": "img/CO2-m.png"
+    "imageUrl": "img/CO2-m.png",
+    "markdownUrl": "data/project_details/4.md"
   },
   {
     "id": 5,
     "title": "Cell Adhesion Study",
     "summary": "Prototype to measure cell adhesion forces using automated tracking.",
-    "content": "<p>I developed a prototype device to investigate cell adhesion in a batch. To do so, we measured displacement of cells in the field of view and estimated the adhesion forces from the parameters of the actuater and measured dispacement. Cell identification is done automatically with the help of cellpose. Based on my prototype a US grant was won by my collaborators.</p>",
-    "imageUrl": "img/bioshake.png"
+    "imageUrl": "img/bioshake.png",
+    "markdownUrl": "data/project_details/5.md"
   },
   {
     "id": 6,
     "title": "Plasma Device Control Unit",
     "summary": "Open-source control and acquisition unit for plasma experiments.",
-    "content": "<p>An open-source based control and acquisition unit was developed for my  plasma irradiation and hydrogen transport investigations (PIHTI). The source code is availiable on <a href='https://github.com/queezz/ControlUnit'>GitHub</a></p>",
-    "imageUrl": "img/ControlUnit.png"
+    "imageUrl": "img/ControlUnit.png",
+    "markdownUrl": "data/project_details/6.md"
   },
   {
     "id": 7,
     "title": "X-ray Filter for Non-destructive Inspection",
     "summary": "Improved X-ray filter design for weld inspection.",
-    "content": "<p>I developed a new filter for X-ray and radio isotope sources used for non-destructive inspecion of welded joints. Significant improvement of the detection limit for defects was achived. This designed was patented, <a href='https://patents.google.com/patent/RU2530452C1/en?oq=RU2530452C1'>RU2530452C1</a>. </p>",
-    "imageUrl": "img/Xrayfilter.jpg"
+    "imageUrl": "img/Xrayfilter.jpg",
+    "markdownUrl": "data/project_details/7.md"
   },
   {
     "id": 8,
     "title": "Permeation Experiments in QUEST",
     "summary": "Hydrogen flux measurements with membrane probes in QUEST tokamak.",
-    "content": "<p>For several years I worked as a member of the QUEST tokamak team. I worked with membrane prboes to detect atomic and ionic hydrogen flux, coming to the walls of the device. Several iterations of the diagnostic were designed and adopted, and several papers regarding hydrogen recycling in QUEST were published.</p>",
-    "imageUrl": "img/kaainquest.jpg"
+    "imageUrl": "img/kaainquest.jpg",
+    "markdownUrl": "data/project_details/8.md"
   },
   {
     "id": 9,
     "title": "Carbon impurity flow in LHD",
     "summary": "Analysis of carbon impurity transport in LHD peripheral plasma.",
-    "content": "<p>I investigated carbon impurity flow in the perefiral plasma of Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>).</p>",
-    "imageUrl": "img/carbonflow.png"
+    "imageUrl": "img/carbonflow.png",
+    "markdownUrl": "data/project_details/9.md"
   },
   {
     "id": 10,
     "title": "Boron powder plasma sputtering",
     "summary": "Prototype sputtering device for boron powder deposition.",
-    "content": "<p>I developed a prototype plasma deposition device where a boron powder is sputtered to simulate deposition of hard BCH films.</p>",
-    "imageUrl": "img/boronpowder.jpg"
+    "imageUrl": "img/boronpowder.jpg",
+    "markdownUrl": "data/project_details/10.md"
   },
   {
     "id": 11,
     "title": "Hydrogen Molecule Spectroscopy",
     "summary": "Spectroscopy of hydrogen molecule populations in LHD plasma.",
-    "content": "<p>We investigated population distribution of hydrogen molecules in Large Helical Device (<a href='https://en.wikipedia.org/wiki/Large_Helical_Device'>LHD</a>) perefiral plasma. The results show non-equilibrium distribution with two rotational temperatures.</p>",
-    "imageUrl": "img/fulcheralpha.png"
+    "imageUrl": "img/fulcheralpha.png",
+    "markdownUrl": "data/project_details/11.md"
   },
   {
     "id": 12,
     "title": "Seawater Desalination Device",
     "summary": "Renewable-powered multi-effect evaporation desalination system.",
-    "content": "<p>I've participated in R&D of a  multi-effect evaporation seawater desalination system based on renewable energy. Plasma deposition was used to increase light absorptivity of the heat pipes to boil water.</p>",
-    "imageUrl": "img/CuFefilm.png"
+    "imageUrl": "img/CuFefilm.png",
+    "markdownUrl": "data/project_details/12.md"
   },
   {
     "id": 13,
     "title": "GUI for Echelle Spectrometer Image processing",
     "summary": "PyQt GUI converts 2D echelle images to calibrated spectra.",
-    "content": "<p>The GUI is developed to work with 2D Echelle images to convert them into calibrated spectra. The GUI is written in <a href='https://wiki.python.org/moin/PyQt'>pyqt</a> and relies on <a href='https://www.pyqtgraph.org/'>pyqtgrph</a> for fast plotting. See the project on <a href='https://github.com/queezz/echelle_spectra'>GitHub</a>.</p>",
-    "imageUrl": "img/echellegui.png"
+    "imageUrl": "img/echellegui.png",
+    "markdownUrl": "data/project_details/13.md"
   },
   {
     "id": 14,
     "title": "Oxygen Effect on Hydrogen Retention in Graphites",
     "summary": "Oxygen addition drastically increases hydrogen retention in graphites.",
-    "content": "<p>We've investigated how oxygen presence in hydrogen plasma affects retention in graphites. Turnes out, addition of a small concentration of oxygen leads to a tremendous increas in retention, even when ion irradiation energy is close to 0, or when irradiating graphites with only electrons.</p>",
-    "imageUrl": "img/D2O2-m.png"
+    "imageUrl": "img/D2O2-m.png",
+    "markdownUrl": "data/project_details/14.md"
   },
   {
     "id": 15,
     "title": "Fulcher-alpha Emission Analizer",
     "summary": "Python tool for analyzing molecular hydrogen Fulcher-alpha emission.",
-    "content": "<p>This python project workes with molecular hydrogen Fulcher-alpha emission. It analized 1 and 2 temperature Boltzman distributino, and calculates rotational and vibrational temperatures of hydrogen molecules in the ground (X) and excited (d) states. The code is avaliable on <a href='https://github.com/queezz/fulcheranalyzer'>GitHub</a>.</p>",
-    "imageUrl": "img/fulcheranalizer.png"
+    "imageUrl": "img/fulcheranalizer.png",
+    "markdownUrl": "data/project_details/15.md"
   }
 ]

--- a/project.html
+++ b/project.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        if (localStorage.getItem('darkMode') === '1') {
+            document.documentElement.classList.add('dark-mode');
+        }
+    </script>
+    <meta charset="UTF-8">
+    <title>Project Details</title>
+    <link rel="stylesheet" href="styles/styles.css">
+    <link rel="stylesheet" href="styles/project.css">
+    <meta name="viewport" content="width=device-width">
+</head>
+<body>
+    <script src="scripts/navbar.js"></script>
+    <nav id="navbar"></nav>
+    <div class="main-content">
+        <a href="projects.html" class="back-link">&larr; Back to Projects</a>
+        <div id="projectContainer" class="project-content"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="scripts/project.js"></script>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -31,13 +31,14 @@
     <div class="main-content">
         <nav id="navbar"></nav>
 
-        <script src="scripts/projects.js"></script>
         <h1>Projects</h1>
         <div class="grid-container" id="gridContainer">
             <!-- Grid items will be added here -->
         </div>
 
     </div>
+
+    <script src="scripts/projects.js"></script>
 
 </body>
 

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -1,0 +1,41 @@
+async function loadProject() {
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (!id) {
+        return;
+    }
+
+    try {
+        const response = await fetch('data/projects.json');
+        const projects = await response.json();
+        const project = projects.find(p => p.id == id);
+        if (!project) {
+            return;
+        }
+
+        document.title = project.title;
+
+        const container = document.getElementById('projectContainer');
+        const header = document.createElement('h1');
+        header.textContent = project.title;
+        container.appendChild(header);
+
+        if (project.imageUrl) {
+            const img = document.createElement('img');
+            img.src = project.imageUrl;
+            img.alt = project.title;
+            container.appendChild(img);
+        }
+
+        const mdResponse = await fetch(project.markdownUrl);
+        const mdText = await mdResponse.text();
+        const html = marked.parse(mdText);
+        const contentDiv = document.createElement('div');
+        contentDiv.innerHTML = html;
+        container.appendChild(contentDiv);
+    } catch (err) {
+        console.error('Error loading project:', err);
+    }
+}
+
+loadProject();

--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -1,20 +1,20 @@
 // Function to fetch and populate data
 async function fetchData() {
     try {
-        const response = await fetch('data/projects.json'); // Replace with the path to your JSON file
+        const response = await fetch('data/projects.json');
         const data = await response.json();
 
         const gridContainer = document.getElementById('gridContainer');
 
         // Create link cards based on the data
-        data.forEach(item => {
+        data.forEach(({ id, title, summary, imageUrl }) => {
             const card = document.createElement('a');
             card.className = 'grid-item';
-            card.href = `project.html?id=${item.id}`;
+            card.href = `project.html?id=${id}`;
             card.innerHTML = `
-                <img src="${item.imageUrl}" alt="${item.title}">
-                <h2>${item.title}</h2>
-                <p>${item.summary}</p>
+                <img src="${imageUrl}" alt="${title}">
+                <h2>${title}</h2>
+                <p>${summary}</p>
             `;
             gridContainer.appendChild(card);
         });

--- a/styles/project.css
+++ b/styles/project.css
@@ -1,0 +1,18 @@
+.back-link {
+    display: inline-block;
+    margin: 20px 0;
+    text-decoration: none;
+    color: #8c0c0c;
+    font-weight: bold;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+.project-content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 20px 0;
+}


### PR DESCRIPTION
## Summary
- move project descriptions from `projects.json` into individual markdown files referenced by a new `markdownUrl`
- add `project.html` and supporting script to render markdown and provide a clear back link to all projects
- update `projects.js` and `projects.html` to link to the new detail pages after the DOM is ready

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689844179ab0832ab2cdd549e7c192f8