### PR TITLE
Fix project page markdown loading on GitHub Pages

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+This file disables Jekyll

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -19,7 +19,8 @@ async function loadProject() {
     const layout = document.createElement("section");
     layout.className = "project-layout";
 
-    const mdText = await (await fetch(project.markdownUrl)).text();
+    const mdPath = project.markdownUrl.replace(/^\//, "");
+    const mdText = await (await fetch(mdPath)).text();
     const { fm, body } = parseFrontMatter(mdText);
 
     // hero/figure


### PR DESCRIPTION
## Summary
- Strip leading slashes from markdown paths before fetching so project details load correctly
- Disable Jekyll processing to serve raw markdown files on GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b3374a30832ab8adb75981de6548