### PR TITLE
fix: prevent profile photo distortion

### DIFF
--- a/styles/about.css
+++ b/styles/about.css
@@ -13,6 +13,7 @@
 
 .photo img {
     max-width: 200px;
+    height: auto;
     border-radius: 8px;
     display: block;
 }
@@ -235,5 +236,6 @@
 
     .photo img {
         max-width: 150px;
+        height: auto;
     }
 }


### PR DESCRIPTION
## Summary
- keep profile photo aspect ratio by resetting image height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c228b27c832a8560ada9dab3425a