### PR TITLE
Display captions in project gallery and lightbox

### DIFF
--- a/scripts/project.js
+++ b/scripts/project.js
@@ -114,7 +114,7 @@ async function loadProject() {
       g.className = "gallery";
        if (fm.gallery.length === 1) g.classList.add("single");
       g.innerHTML = fm.gallery.map(
-        item => `<figure><img src="${item.src}" alt="" loading="lazy" decoding="async"${sizeAttr(item.src)}>
+        item => `<figure><div class="thumb"><img src="${item.src}" alt="" loading="lazy" decoding="async"${sizeAttr(item.src)}></div>`
           ${item.caption ? `<figcaption>${escapeHtml(item.caption)}</figcaption>` : ""}</figure>`
         ).join("");
         container.appendChild(g);

--- a/styles/project.css
+++ b/styles/project.css
@@ -35,8 +35,22 @@
   grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
 }
 .gallery figure{margin:0}
-.gallery:not(.single) figure{aspect-ratio:1/1;overflow:hidden}
-.gallery img{width:100%;height:100%;display:block;border-radius:10px;object-fit:cover;cursor:pointer}
+.gallery .thumb{
+  position:relative;
+  width:100%;
+  padding-top:100%;
+  overflow:hidden;
+  border-radius:10px;
+  cursor:pointer;
+}
+.gallery .thumb img{
+  position:absolute;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
 .gallery figcaption{margin-top:.35rem;font-size:.85rem;opacity:.8}
 
 @media (max-width:900px){
@@ -44,7 +58,7 @@
   .project-figure img{max-height:none}
 }
 /* --- single-image gallery clamp --- */
-.gallery.single { 
+.gallery.single {
   display: block;
   margin: 1.5rem auto;
 }
@@ -56,7 +70,13 @@
 }
 
 /* ensure it's not cropped*/
-.gallery.single img {
+.gallery.single .thumb {
+  padding-top: 0;
+  overflow: visible;
+  border-radius: 12px;
+}
+.gallery.single .thumb img {
+  position: static;
   width: 100%;
   height: auto;
   object-fit: contain;
@@ -83,14 +103,29 @@
   cursor:zoom-out;
 }
 #imgLightbox.show{display:flex}
-#imgLightbox img{
+#imgLightbox figure{
+  margin:0;
+  text-align:center;
+  position:relative;
   max-width:90%;
   max-height:90%;
+}
+#imgLightbox img{
+  max-width:100%;
+  max-height:100%;
   border-radius:12px;
   box-shadow:0 6px 24px rgba(0,0,0,.25);
 }
-#imgLightbox figure{margin:0;text-align:center}
-#imgLightbox figcaption{margin-top:.5rem;color:#fff}
+#imgLightbox figcaption{
+  position:absolute;
+  bottom:0;
+  left:0;
+  width:100%;
+  padding:.5rem;
+  box-sizing:border-box;
+  background:rgba(0,0,0,.6);
+  color:#fff;
+}
 #imgLightbox .nav{
   position:absolute;
   top:50%;


### PR DESCRIPTION
## Summary
- Ensure gallery thumbnails remain square by wrapping images in a dedicated container and cropping with CSS
- Adjust single-image gallery styling so large images display at full size without distortion
- Inject the new wrapper via JavaScript when rendering project galleries

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory, open '/workspace/queezz.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68994a45c4dc832a826a4da89b94f7eb